### PR TITLE
refactor: complete runtime interface inversion

### DIFF
--- a/src/anteumbra/application/launcher.py
+++ b/src/anteumbra/application/launcher.py
@@ -11,7 +11,6 @@ from typing import Any, Callable, Protocol
 from anteumbra.application.jsonl_consumer import JsonlEventTailer
 from anteumbra.application.runtime_builder import (
     RuntimeLifecycleDependencies,
-    build_runtime_lifecycle_dependencies,
 )
 from anteumbra.application.runtime_container import RuntimeContainer
 from anteumbra.application.runtime_health_service import assess_runtime_capabilities
@@ -88,7 +87,7 @@ class RuntimeLifecycle:
         self.host = host
         self.port = port
         self._config_provider = config_provider
-        self._dependencies = dependencies or build_runtime_lifecycle_dependencies()
+        self._dependencies = dependencies
         self._lock = threading.RLock()
         self._state = RuntimeState()
 
@@ -99,6 +98,8 @@ class RuntimeLifecycle:
                 raise RuntimeError("Runtime lifecycle is already active")
 
         dependencies = self._dependencies
+        if dependencies is None:
+            raise RuntimeStartupError("Runtime dependencies were not supplied")
         provider = self._config_provider or dependencies.config_provider_factory()
         config = provider.get()
         data_dir = dependencies.path_normalizer(config.get("paths", {}).get("data_dir", "data"))

--- a/src/anteumbra/application/runtime_builder.py
+++ b/src/anteumbra/application/runtime_builder.py
@@ -243,8 +243,12 @@ class RuntimeLifecycleDependencies:
     alert_formatter: Callable[[dict[str, object]], str]
 
 
-def build_runtime_lifecycle_dependencies() -> RuntimeLifecycleDependencies:
-    """Assemble concrete lifecycle capabilities at the composition root."""
+def build_runtime_lifecycle_dependencies(
+    *,
+    app_factory: Callable[..., object],
+    server_factory: Callable[..., object],
+) -> RuntimeLifecycleDependencies:
+    """Assemble concrete lifecycle capabilities with injected web adapters."""
     from anteumbra.application.runtime_adapters import build_runtime_services
     from anteumbra.infrastructure.config.provider import TomlConfigProvider
     from anteumbra.infrastructure.monitoring.log_analyzer import (
@@ -258,7 +262,6 @@ def build_runtime_lifecycle_dependencies() -> RuntimeLifecycleDependencies:
         write_process_identity,
     )
     from anteumbra.infrastructure.utils.path_utils import normalize_path
-    from anteumbra.interfaces.web.factory import create_app, create_runtime_server
 
     return RuntimeLifecycleDependencies(
         config_provider_factory=TomlConfigProvider,
@@ -268,8 +271,8 @@ def build_runtime_lifecycle_dependencies() -> RuntimeLifecycleDependencies:
         process_identity_remover=remove_process_identity,
         container_builder=build_runtime_container,
         runtime_services_builder=build_runtime_services,
-        app_factory=create_app,
-        server_factory=create_runtime_server,
+        app_factory=app_factory,
+        server_factory=server_factory,
         monitor_factory=WebsiteMonitor,
         analyzer_factory=get_analyzer,
         log_monitor_factory=LogMonitor,

--- a/src/anteumbra/cli/lifecycle_commands.py
+++ b/src/anteumbra/cli/lifecycle_commands.py
@@ -68,9 +68,21 @@ def register_lifecycle_commands(
         click.echo(f"  PID:     {deps.os_module.getpid()}")
 
         from anteumbra.application.launcher import RuntimeLifecycle, RuntimeStartupError
+        from anteumbra.application.runtime_builder import (
+            build_runtime_lifecycle_dependencies,
+        )
+        from anteumbra.interfaces.web.factory import create_app, create_runtime_server
 
         try:
-            RuntimeLifecycle(host=host, port=port).run()
+            runtime_dependencies = build_runtime_lifecycle_dependencies(
+                app_factory=create_app,
+                server_factory=create_runtime_server,
+            )
+            RuntimeLifecycle(
+                host=host,
+                port=port,
+                dependencies=runtime_dependencies,
+            ).run()
         except RuntimeStartupError as exc:
             raise click.ClickException(str(exc)) from exc
 

--- a/tests/architecture/test_cleanup_ratchet.py
+++ b/tests/architecture/test_cleanup_ratchet.py
@@ -87,13 +87,13 @@ def test_module_size_baseline_records_cleanup_starting_point():
     assert not growth, f"cleanup target modules must not grow beyond baseline: {growth}"
 
 
-def test_stage_one_must_retire_the_only_application_to_interface_edge():
+def test_application_does_not_depend_on_interfaces():
     edges = {
         edge.key
         for edge in _internal_import_edges()
         if edge.source_layer == "application" and edge.imported_layer == "interfaces"
     }
-    assert edges == {("application/runtime_builder.py", "anteumbra.interfaces.web.factory")}
+    assert not edges
 
 
 def _route_contract(filename: str, blueprint: str) -> set[tuple[str, tuple[str, ...], bool]]:

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -81,10 +81,7 @@ def _format_edges(edges: Iterable[ImportEdge]) -> str:
     )
 
 
-# The launcher is the composition root and may start the web interface.
-KNOWN_APPLICATION_TO_INTERFACES: set[tuple[str, str]] = {
-    ("application/runtime_builder.py", "anteumbra.interfaces.web.factory"),
-}
+KNOWN_APPLICATION_TO_INTERFACES: set[tuple[str, str]] = set()
 
 
 KNOWN_LEGACY_BRANDING_LINES: set[tuple[str, str]] = {

--- a/tests/e2e/test_deployment.py
+++ b/tests/e2e/test_deployment.py
@@ -975,9 +975,13 @@ class TestCliInstall:
         from anteumbra.application.runtime_builder import (
             build_runtime_lifecycle_dependencies,
         )
+        from anteumbra.interfaces.web.factory import create_app, create_runtime_server
 
         dependencies = replace(
-            build_runtime_lifecycle_dependencies(),
+            build_runtime_lifecycle_dependencies(
+                app_factory=create_app,
+                server_factory=create_runtime_server,
+            ),
             container_builder=lambda **_kwargs: pytest.fail(
                 "runtime must not be built before validation"
             ),


### PR DESCRIPTION
Removes the final application-to-interfaces dependency by injecting the web app and server factories at the CLI composition boundary. The architecture allowlist is now empty and the ratchet enforces zero Application-to-Interfaces edges. Validation: Ruff and format checks passed; 544 non-browser tests passed at 62.22% coverage; 43 Playwright UI tests passed. This PR does not publish to PyPI or upgrade the deployed instance.